### PR TITLE
Improve postgres deployment

### DIFF
--- a/schema/postgres/panda_db_init.sh
+++ b/schema/postgres/panda_db_init.sh
@@ -28,7 +28,7 @@ IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_VERSION"
 
 if [ -z "$CURRENT_VERSION" ]; then
     # new database
-    psql -d panda_db -U postgres -c "INSERT INTO doma_panda.pandadb_version (component, major, minor, patch) VALUES('SCHEMA', '${MAJOR}', '${MINOR}', '${PATCH}')"
+    echo ========== this is a new database, we will proceed with the creation of the schema "$LATEST_VERSION"
 else
     echo "Latest: $LATEST_VERSION   Current: $CURRENT_VERSION"
     # exit if already latest
@@ -69,6 +69,9 @@ do
         fi
     done
 done
+
+echo ========== adding the schema version "$LATEST_VERSION"
+psql -d panda_db -U postgres -c "INSERT INTO doma_panda.pandadb_version (component, major, minor, patch) VALUES('SCHEMA', '${MAJOR}', '${MINOR}', '${PATCH}')"
 
 echo ========== post step
 psql -U postgres -d panda_db -f $DIR/post_step_panda.sql

--- a/schema/postgres/panda_db_init.sh
+++ b/schema/postgres/panda_db_init.sh
@@ -22,13 +22,13 @@ echo
 
 # check schema version
 LATEST_VERSION=$(cat ${DIR}/version)
-CURRENT_VERSION=$(psql -d panda_db -U postgres -tc "SELECT major || '.' ||  minor || '.' || patch FROM pandadb_version WHERE component = 'SCHEMA'")
+CURRENT_VERSION=$(psql -d panda_db -U postgres -tc "SELECT major || '.' ||  minor || '.' || patch FROM doma_panda.pandadb_version WHERE component = 'SCHEMA'")
 
 IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_VERSION"
 
 if [ -z "$CURRENT_VERSION" ]; then
     # new database
-    psql -d panda_db -U postgres -c "INSERT INTO pandadb_version (component, major, minor, patch) VALUES('SCHEMA', '${MAJOR}', '${MINOR}', '${PATCH}')"
+    psql -d panda_db -U postgres -c "INSERT INTO doma_panda.pandadb_version (component, major, minor, patch) VALUES('SCHEMA', '${MAJOR}', '${MINOR}', '${PATCH}')"
 else
     echo "Latest: $LATEST_VERSION   Current: $CURRENT_VERSION"
     # exit if already latest
@@ -45,7 +45,7 @@ else
         fi
     done
     # update version
-    psql -d panda_db -U postgres -c "UPDATE pandadb_version set major='${MAJOR}', minor='${MINOR}', patch='${PATCH}' WHERE component = 'SCHEMA'"
+    psql -d panda_db -U postgres -c "UPDATE doma_panda.pandadb_version set major='${MAJOR}', minor='${MINOR}', patch='${PATCH}' WHERE component = 'SCHEMA'"
     echo ========== updated to the latest schema "$LATEST_VERSION"
     exit 0
 fi

--- a/schema/postgres/sqls/init_step.sql
+++ b/schema/postgres/sqls/init_step.sql
@@ -7,6 +7,11 @@ GRANT USAGE ON SCHEMA cron TO panda;
 CREATE SCHEMA IF NOT EXISTS partman;
 CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;
 
+CREATE SCHEMA IF NOT EXISTS doma_panda;
+ALTER SCHEMA doma_panda OWNER TO panda;
+
+SET search_path = doma_panda,public;
+
 --- schema version
 CREATE TABLE IF NOT EXISTS  pandadb_version (
 	component varchar(100) NOT NULL,

--- a/schema/postgres/sqls/init_step.sql
+++ b/schema/postgres/sqls/init_step.sql
@@ -6,17 +6,3 @@ GRANT USAGE ON SCHEMA cron TO panda;
 \c panda_db;
 CREATE SCHEMA IF NOT EXISTS partman;
 CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;
-
-CREATE SCHEMA IF NOT EXISTS doma_panda;
-ALTER SCHEMA doma_panda OWNER TO panda;
-
-SET search_path = doma_panda,public;
-
---- schema version
-CREATE TABLE IF NOT EXISTS  pandadb_version (
-	component varchar(100) NOT NULL,
-	major INT NOT NULL,
-	minor INT NOT NULL,
-	patch INT NOT NULL
-) ;
-GRANT ALL ON pandadb_version TO panda;

--- a/schema/postgres/sqls/pg_PANDA_TABLE.sql
+++ b/schema/postgres/sqls/pg_PANDA_TABLE.sql
@@ -13,6 +13,17 @@ ALTER SCHEMA doma_panda OWNER TO panda;
 
 SET search_path = doma_panda,public;
 
+--- schema version
+CREATE TABLE IF NOT EXISTS  pandadb_version (
+	component varchar(100) NOT NULL,
+	major INT NOT NULL,
+	minor INT NOT NULL,
+	patch INT NOT NULL
+) ;
+ALTER TABLE pandadb_version TO panda;
+--GRANT ALL ON pandadb_version TO postgres;
+ALTER TABLE pandadb_version ADD PRIMARY KEY (component);
+
 CREATE TABLE cache (
 	main_key varchar(56) NOT NULL,
 	sub_key varchar(56) NOT NULL,

--- a/schema/postgres/sqls/pg_PANDA_TABLE.sql
+++ b/schema/postgres/sqls/pg_PANDA_TABLE.sql
@@ -20,7 +20,7 @@ CREATE TABLE pandadb_version (
 	minor INT NOT NULL,
 	patch INT NOT NULL
 ) ;
-ALTER TABLE pandadb_version TO panda;
+ALTER TABLE pandadb_version OWNER TO panda;
 --GRANT ALL ON pandadb_version TO postgres;
 ALTER TABLE pandadb_version ADD PRIMARY KEY (component);
 

--- a/schema/postgres/sqls/pg_PANDA_TABLE.sql
+++ b/schema/postgres/sqls/pg_PANDA_TABLE.sql
@@ -14,7 +14,7 @@ ALTER SCHEMA doma_panda OWNER TO panda;
 SET search_path = doma_panda,public;
 
 --- schema version
-CREATE TABLE IF NOT EXISTS  pandadb_version (
+CREATE TABLE pandadb_version (
 	component varchar(100) NOT NULL,
 	major INT NOT NULL,
 	minor INT NOT NULL,


### PR DESCRIPTION
Changed the schema for the pandadb_version in postgres from public to doma_panda so we won't have to patch the WrappedCursor in pandaserver/taskbuffer

The issue was coming from the fact that previously the postgres init script was creating the pandadb_version in the public schema and not in the doma_panda. Which in principle it is fine but then the WrappedCursor in pandaserver/taskbuffer was adding the panda_config.schema in the query and a simple `select * from doma_panda.pandadb_version;` fails. The only way to make it work was by patching the WrappedCursor to remove `doma_panda.` from the query that checks the pandadb version schema.

Now the init script creates this table in the doma_panda schema and not in the public schema 