### PR TITLE
Updated oracle and psql schema to include Jedi and Server schema versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Oracle and PostgreSQL DB schema for PanDA and Container image for PandaDB
 
-For instructions please refer to the [official PanDA documentation](https://panda-wms.readthedocs.io/en/latest/).
+For instructions please refer to the Database > Database Administration section of the [official PanDA documentation](https://panda-wms.readthedocs.io/en/latest/).

--- a/schema/oracle/ATLAS_PANDA.sql
+++ b/schema/oracle/ATLAS_PANDA.sql
@@ -35,6 +35,8 @@
 --------------------------------------------------------
   
   INSERT INTO "ATLAS_PANDA"."PANDADB_VERSION" VALUES ('SCHEMA', 0, 0, 12);
+  INSERT INTO "ATLAS_PANDA"."PANDADB_VERSION" VALUES ('SERVER', 0, 0, 12);
+  INSERT INTO "ATLAS_PANDA"."PANDADB_VERSION" VALUES ('JEDI', 0, 0, 12);
 
 --------------------------------------------------------
 --  DDL for Sequence CLOUDTASKS_ID_SEQ

--- a/schema/postgres/panda_db_init.sh
+++ b/schema/postgres/panda_db_init.sh
@@ -72,6 +72,9 @@ done
 
 echo ========== adding the schema version "$LATEST_VERSION"
 psql -d panda_db -U postgres -c "INSERT INTO doma_panda.pandadb_version (component, major, minor, patch) VALUES('SCHEMA', '${MAJOR}', '${MINOR}', '${PATCH}')"
+psql -d panda_db -U postgres -c "INSERT INTO doma_panda.pandadb_version (component, major, minor, patch) VALUES('SERVER', '${MAJOR}', '${MINOR}', '${PATCH}')"
+psql -d panda_db -U postgres -c "INSERT INTO doma_panda.pandadb_version (component, major, minor, patch) VALUES('JEDI', '${MAJOR}', '${MINOR}', '${PATCH}')"
+
 
 echo ========== post step
 psql -U postgres -d panda_db -f $DIR/post_step_panda.sql

--- a/schema/postgres/panda_db_init.sh
+++ b/schema/postgres/panda_db_init.sh
@@ -46,6 +46,8 @@ else
     done
     # update version
     psql -d panda_db -U postgres -c "UPDATE doma_panda.pandadb_version set major='${MAJOR}', minor='${MINOR}', patch='${PATCH}' WHERE component = 'SCHEMA'"
+    psql -d panda_db -U postgres -c "UPDATE doma_panda.pandadb_version set major='${MAJOR}', minor='${MINOR}', patch='${PATCH}' WHERE component = 'SERVER'"
+    psql -d panda_db -U postgres -c "UPDATE doma_panda.pandadb_version set major='${MAJOR}', minor='${MINOR}', patch='${PATCH}' WHERE component = 'JEDI'"
     echo ========== updated to the latest schema "$LATEST_VERSION"
     exit 0
 fi


### PR DESCRIPTION
Updated oracle and psql schema to include Jedi and Server schema versions - at the moment I've left the 'SCHEMA' component but in the future I might remove it depending if I/we find a use-case for it or not.