### PR TITLE
Rubin panda db deploy on CNPG

### DIFF
--- a/rubin-panda-db-deploy/overlays/idds/dev/main/Makefile
+++ b/rubin-panda-db-deploy/overlays/idds/dev/main/Makefile
@@ -1,11 +1,9 @@
 
 SECRET_PATH ?= secret/rubin/usdf-panda-idds/postgres
-S3_SECRET_PATH ?= secret/rubin/usdf-panda-idds/weka-s3
 
 get-secrets-from-vault:
 	mkdir -p etc/.secrets/
 	set -e; for i in username password; do vault kv get --field=$$i $(SECRET_PATH) > etc/.secrets/$$i ; done
-	set -e; for i in client-id client-secret; do vault kv get --field=$$i $(S3_SECRET_PATH) > etc/.secrets/$$i ; done
 
 clean-secrets:
 	rm -rf etc/.secrets/

--- a/rubin-panda-db-deploy/overlays/idds/prod/archive/backup.yaml
+++ b/rubin-panda-db-deploy/overlays/idds/prod/archive/backup.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: usdf-panda-backup
+spec:
+  immediate: true
+  schedule: "0 0 0 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: usdf-panda-idds

--- a/rubin-panda-db-deploy/overlays/idds/prod/archive/cnpg-panda-idds-database.yaml
+++ b/rubin-panda-db-deploy/overlays/idds/prod/archive/cnpg-panda-idds-database.yaml
@@ -4,6 +4,19 @@ kind: Cluster
 metadata:
   name: usdf-panda-idds
 spec:
+  spec:
+    backup:
+      retentionPolicy: "15d"
+      barmanObjectStore:
+        destinationPath: s3://rubin-usdf-panda
+        endpointURL: http://sdfk8s001.slac.stanford.edu:9000
+        s3Credentials:
+          accessKeyId:
+            name: s3-creds
+            key: ACCESS_KEY_ID
+          secretAccessKey:
+            name: s3-creds
+            key: ACCESS_SECRET_KEY
   instances: 2
   primaryUpdateStrategy: unsupervised
 

--- a/rubin-panda-db-deploy/overlays/idds/prod/main/backup.yaml
+++ b/rubin-panda-db-deploy/overlays/idds/prod/main/backup.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: usdf-panda-backup
+spec:
+  immediate: true
+  schedule: "0 0 0 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: usdf-panda-idds

--- a/rubin-panda-db-deploy/overlays/idds/prod/main/cnpg-panda-idds-database.yaml
+++ b/rubin-panda-db-deploy/overlays/idds/prod/main/cnpg-panda-idds-database.yaml
@@ -4,6 +4,19 @@ kind: Cluster
 metadata:
   name: usdf-panda-idds
 spec:
+  spec:
+    backup:
+      retentionPolicy: "15d"
+      barmanObjectStore:
+        destinationPath: s3://rubin-usdf-panda
+        endpointURL: http://sdfk8s001.slac.stanford.edu:9000
+        s3Credentials:
+          accessKeyId:
+            name: s3-creds
+            key: ACCESS_KEY_ID
+          secretAccessKey:
+            name: s3-creds
+            key: ACCESS_SECRET_KEY
   instances: 2
   primaryUpdateStrategy: unsupervised
 

--- a/rubin-panda-db-deploy/overlays/panda/dev/Makefile
+++ b/rubin-panda-db-deploy/overlays/panda/dev/Makefile
@@ -1,11 +1,9 @@
 
 SECRET_PATH ?= secret/rubin/usdf-panda-idds/postgres
-S3_SECRET_PATH ?= secret/rubin/usdf-panda-idds/weka-s3
 
 get-secrets-from-vault:
 	mkdir -p etc/.secrets/
 	set -e; for i in username password; do vault kv get --field=$$i $(SECRET_PATH) > etc/.secrets/$$i ; done
-	set -e; for i in client-id client-secret; do vault kv get --field=$$i $(S3_SECRET_PATH) > etc/.secrets/$$i ; done
 
 clean-secrets:
 	rm -rf etc/.secrets/

--- a/rubin-panda-db-deploy/overlays/panda/prod/backup.yaml
+++ b/rubin-panda-db-deploy/overlays/panda/prod/backup.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: usdf-panda-backup
+spec:
+  immediate: true
+  schedule: "0 0 0 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: usdf-panda-idds

--- a/rubin-panda-db-deploy/overlays/panda/prod/cnpg-panda-server-database.yaml
+++ b/rubin-panda-db-deploy/overlays/panda/prod/cnpg-panda-server-database.yaml
@@ -5,7 +5,7 @@ metadata:
   # note the name is the DB services/pods  not the Cluster name.
   name: usdf-panda-server
 spec:
-  instances: 1
+  instances: 2
   primaryUpdateStrategy: unsupervised
 
   bootstrap:

--- a/rubin-panda-db-deploy/overlays/panda/prod/cnpg-panda-server-database.yaml
+++ b/rubin-panda-db-deploy/overlays/panda/prod/cnpg-panda-server-database.yaml
@@ -5,6 +5,19 @@ metadata:
   # note the name is the DB services/pods  not the Cluster name.
   name: usdf-panda-server
 spec:
+  spec:
+    backup:
+      retentionPolicy: "15d"
+      barmanObjectStore:
+        destinationPath: s3://rubin-usdf-panda
+        endpointURL: http://sdfk8s001.slac.stanford.edu:9000
+        s3Credentials:
+          accessKeyId:
+            name: s3-creds
+            key: ACCESS_KEY_ID
+          secretAccessKey:
+            name: s3-creds
+            key: ACCESS_SECRET_KEY
   instances: 2
   primaryUpdateStrategy: unsupervised
 


### PR DESCRIPTION
- removed s3 bucket for dev env and changed panda prod instance number to 2 (from 1)
- added backup policy for prod env
- defined a backup resource