### PR TITLE
Fixing partitioning error: ERROR:  Control column given (ins_utc_tsta…

### DIFF
--- a/schema/postgres/sqls/pg_PANDA_TABLE.sql
+++ b/schema/postgres/sqls/pg_PANDA_TABLE.sql
@@ -781,7 +781,7 @@ CREATE TABLE jedi_job_retry_history (
 	jeditaskid bigint NOT NULL,
 	oldpandaid bigint NOT NULL,
 	newpandaid bigint NOT NULL,
-	ins_utc_tstamp timestamp DEFAULT ((CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC')),
+	ins_utc_tstamp timestamp NOT NULL DEFAULT ((CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC')),
 	relationtype varchar(16),
 	originpandaid bigint
 ) PARTITION BY RANGE (ins_utc_tstamp) ;


### PR DESCRIPTION
…mp) for parent table (doma_panda.jedi_job_retry_history) does not exist or must be set to NOT NULL