### PR TITLE
Add ARCHITECTURE and DRIVER_VERSION to MV_WORKER_NODE_GPU_SUMMARY

### DIFF
--- a/schema/oracle/ATLAS_PANDA.sql
+++ b/schema/oracle/ATLAS_PANDA.sql
@@ -34,7 +34,7 @@
 --  IMPORTANT: Please always update to up2date version
 --------------------------------------------------------
   
-  INSERT INTO "ATLAS_PANDA"."PANDADB_VERSION" VALUES ('PanDA', 0, 1, 3);
+  INSERT INTO "ATLAS_PANDA"."PANDADB_VERSION" VALUES ('PanDA', 0, 1, 4);
  --------------------------------------------------------
 --  DDL for Sequence FILESTABLE4_ROW_ID_SEQ
 --------------------------------------------------------

--- a/schema/oracle/ATLAS_PANDA_VIEW.sql
+++ b/schema/oracle/ATLAS_PANDA_VIEW.sql
@@ -33,8 +33,10 @@ SELECT
   wng.vendor,
   wng.model,
   wng.vram,
+  wng.architecture,
   wng.framework,
   wng.framework_version,
+  wng.driver_version,
   wng.count AS gpus_per_host,
   COUNT(*) AS host_count
 FROM ATLAS_PANDA.worker_node_gpus wng,
@@ -48,8 +50,10 @@ GROUP BY
   wng.vendor,
   wng.model,
   wng.vram,
+  wng.architecture,
   wng.framework,
   wng.framework_version,
+  wng.driver_version,
   wng.count;
 
 GRANT SELECT ON ATLAS_PANDA.MV_WORKER_NODE_SUMMARY     TO ATLAS_PANDA_READER;

--- a/schema/postgres/sqls/patches/0.1.4.patch.sql
+++ b/schema/postgres/sqls/patches/0.1.4.patch.sql
@@ -1,0 +1,56 @@
+-- patch to be used to upgrade from version 0.1.3
+
+SET search_path = doma_panda,public;
+
+-- ===============================================
+-- Add architecture and driver_version to MV_WORKER_NODE_GPU_SUMMARY
+-- These fields are available in worker_node_gpus but were not projected
+-- into the summary MV, preventing their use in GPU brokerage.
+-- ===============================================
+DROP MATERIALIZED VIEW IF EXISTS doma_panda.mv_worker_node_gpu_summary;
+
+CREATE MATERIALIZED VIEW doma_panda.mv_worker_node_gpu_summary AS
+SELECT
+  wng.site,
+  wnq.panda_queue,
+  wng.vendor,
+  wng.model,
+  wng.vram,
+  wng.architecture,
+  wng.framework,
+  wng.framework_version,
+  wng.driver_version,
+  wng.count AS gpus_per_host,
+  COUNT(*)  AS host_count
+FROM doma_panda.worker_node_gpus  AS wng,
+     doma_panda.worker_node_queue AS wnq
+WHERE wng.last_seen > (CURRENT_TIMESTAMP - INTERVAL '1 month')
+  AND wng.site      = wnq.site
+  AND wng.host_name = wnq.host_name
+GROUP BY
+  wng.site,
+  wnq.panda_queue,
+  wng.vendor,
+  wng.model,
+  wng.vram,
+  wng.architecture,
+  wng.framework,
+  wng.framework_version,
+  wng.driver_version,
+  wng.count
+WITH NO DATA;
+
+ALTER MATERIALIZED VIEW doma_panda.mv_worker_node_gpu_summary OWNER TO panda;
+
+CREATE UNIQUE INDEX ux_mv_wn_gpu_summary
+  ON doma_panda.mv_worker_node_gpu_summary
+  (site, panda_queue, vendor, model, vram, architecture, framework, framework_version, driver_version, gpus_per_host);
+
+REFRESH MATERIALIZED VIEW doma_panda.mv_worker_node_gpu_summary;
+
+-- =========================
+-- Version bump
+-- =========================
+UPDATE doma_panda.pandadb_version
+SET major = 0, minor = 1, patch = 4
+WHERE component = 'PanDA';

--- a/schema/postgres/sqls/pg_PANDA_SCHEDULER_JOBS.sql
+++ b/schema/postgres/sqls/pg_PANDA_SCHEDULER_JOBS.sql
@@ -2473,3 +2473,43 @@ END;
 $$;
 
 ALTER PROCEDURE doma_panda.update_worker_node_metrics() OWNER TO panda;
+
+
+-- GPU inventory summary: per-queue aggregation of GPU hardware info reported by pilots
+-- Refreshed hourly via pg_cron (see post_step_cron.sql)
+CREATE MATERIALIZED VIEW IF NOT EXISTS doma_panda.mv_worker_node_gpu_summary AS
+SELECT
+  wng.site,
+  wnq.panda_queue,
+  wng.vendor,
+  wng.model,
+  wng.vram,
+  wng.architecture,
+  wng.framework,
+  wng.framework_version,
+  wng.driver_version,
+  wng.count AS gpus_per_host,
+  COUNT(*)  AS host_count
+FROM doma_panda.worker_node_gpus  AS wng,
+     doma_panda.worker_node_queue AS wnq
+WHERE wng.last_seen > (CURRENT_TIMESTAMP - INTERVAL '1 month')
+  AND wng.site      = wnq.site
+  AND wng.host_name = wnq.host_name
+GROUP BY
+  wng.site,
+  wnq.panda_queue,
+  wng.vendor,
+  wng.model,
+  wng.vram,
+  wng.architecture,
+  wng.framework,
+  wng.framework_version,
+  wng.driver_version,
+  wng.count
+WITH NO DATA;
+
+ALTER MATERIALIZED VIEW doma_panda.mv_worker_node_gpu_summary OWNER TO panda;
+
+CREATE UNIQUE INDEX ux_mv_wn_gpu_summary
+  ON doma_panda.mv_worker_node_gpu_summary
+  (site, panda_queue, vendor, model, vram, architecture, framework, framework_version, driver_version, gpus_per_host);


### PR DESCRIPTION
## Summary

- Adds `ARCHITECTURE` and `DRIVER_VERSION` columns to `MV_WORKER_NODE_GPU_SUMMARY` (both Oracle and PostgreSQL) — these fields exist in the source `worker_node_gpus` table but were not projected into the MV
- Adds the MV definition to `pg_PANDA_SCHEDULER_JOBS.sql` (base schema) so fresh PostgreSQL installations include it
- New PostgreSQL patch `0.1.4.patch.sql` to upgrade existing deployments

## Motivation

Required by ATLASPANDA-1684 (GPU brokerage enhancements). The brokerage in panda-server will use these fields to filter queues by GPU microarchitecture generation (Volta, Ampere, Hopper...) and NVIDIA driver version / CUDA compatibility. The companion panda-server PR uses CRIC as a GPU capability gate and the WN GPU monitoring MV as the source for all attribute checks.

## Oracle upgrade script

See the DB-upgrade-scripts wiki page (WiP entry for DB version 0.1.4).

## Test plan

- [ ] Apply `0.1.4.patch.sql` to DOMA PostgreSQL and verify `mv_worker_node_gpu_summary` has the new columns populated
- [ ] Verify Oracle MV can be dropped and recreated with the new definition
- [ ] Confirm `GRANT SELECT` to `ATLAS_PANDA_READER` is in place