### PR TITLE
Add index on jedi_tasks (reqid, username) to speed up reqID to taskIDs lookup

### DIFF
--- a/schema/oracle/ATLAS_PANDA.sql
+++ b/schema/oracle/ATLAS_PANDA.sql
@@ -1,6 +1,6 @@
 --------------------------------------------------------
 --  File created - Wednesday-October-19-2022   
---  Schema version: 0.1.5
+--  Schema version: 0.1.6
 --  IMPORTANT: Please always update version below 
 --  to match the current DB schema
 --------------------------------------------------------
@@ -34,7 +34,7 @@
 --  IMPORTANT: Please always update to up2date version
 --------------------------------------------------------
   
-  INSERT INTO "ATLAS_PANDA"."PANDADB_VERSION" VALUES ('PanDA', 0, 1, 5);
+  INSERT INTO "ATLAS_PANDA"."PANDADB_VERSION" VALUES ('PanDA', 0, 1, 6);
  --------------------------------------------------------
 --  DDL for Sequence FILESTABLE4_ROW_ID_SEQ
 --------------------------------------------------------

--- a/schema/oracle/ATLAS_PANDA.sql
+++ b/schema/oracle/ATLAS_PANDA.sql
@@ -4146,7 +4146,13 @@ CREATE INDEX "ATLAS_PANDA"."JOBSDEF_SHARE_STATS_SS_IDX" ON "ATLAS_PANDA"."JOBSDE
 --  DDL for Index JEDI_TASKS_AMIFLAG_IDX
 --------------------------------------------------------
 
-  CREATE INDEX "ATLAS_PANDA"."JEDI_TASKS_AMIFLAG_IDX" ON "ATLAS_PANDA"."JEDI_TASKS" ("AMIFLAG") 
+  CREATE INDEX "ATLAS_PANDA"."JEDI_TASKS_AMIFLAG_IDX" ON "ATLAS_PANDA"."JEDI_TASKS" ("AMIFLAG")
+  ;
+--------------------------------------------------------
+--  DDL for Index JEDI_TASKS_REQID_IDX
+--------------------------------------------------------
+
+  CREATE INDEX "ATLAS_PANDA"."JEDI_TASKS_REQID_IDX" ON "ATLAS_PANDA"."JEDI_TASKS" ("REQID", "USERNAME")
   ;
 --------------------------------------------------------
 --  DDL for Index JOBSARCHIVED4_JOBSETID_IDX

--- a/schema/postgres/sqls/patches/0.1.6.patch.sql
+++ b/schema/postgres/sqls/patches/0.1.6.patch.sql
@@ -1,0 +1,20 @@
+-- patch to be used to upgrade from version 0.1.5
+
+SET search_path = doma_panda,public;
+
+-- ===============================================
+-- Index on jedi_tasks (reqid, username) for reqID->taskIDs lookup (ATLASPANDA-1766)
+-- ===============================================
+
+-- The query "SELECT jeditaskid FROM jedi_tasks WHERE username=? AND modificationtime>sysdate-90 AND reqid=?"
+-- was doing a full table scan across all partitions because jedi_tasks is partitioned by jeditaskid
+-- and no index existed on reqid or username. A composite index on (reqid, username) allows Oracle/PG
+-- to resolve the equality predicates directly and skip the full scan entirely.
+CREATE INDEX IF NOT EXISTS jedi_tasks_reqid_idx ON doma_panda.jedi_tasks (reqid, username);
+
+-- =========================
+-- Version bump
+-- =========================
+UPDATE doma_panda.pandadb_version
+SET major = 0, minor = 1, patch = 6
+WHERE component = 'PanDA';

--- a/schema/postgres/sqls/pg_PANDA_TABLE.sql
+++ b/schema/postgres/sqls/pg_PANDA_TABLE.sql
@@ -1008,6 +1008,7 @@ COMMENT ON COLUMN jedi_tasks.queuedtime IS E'Start time of queuing period ready 
 COMMENT ON COLUMN jedi_tasks.actiontime IS E'Timestamp when a periodic action is executed on the task';
 ALTER  TABLE jedi_tasks OWNER TO panda;
 CREATE INDEX jedi_tasks_amiflag_idx ON jedi_tasks (amiflag);
+CREATE INDEX jedi_tasks_reqid_idx ON jedi_tasks (reqid, username);
 CREATE INDEX jedi_tasks_creation_idx ON jedi_tasks (creationdate);
 CREATE INDEX jedi_tasks_lockedby_idx ON jedi_tasks (lockedby);
 CREATE INDEX jedi_tasks_modiftime_idx ON jedi_tasks (modificationtime);


### PR DESCRIPTION
Fixes ATLASPANDA-1766.

The query used by pbook to fetch taskIDs for a given reqID:

```sql
SELECT jeditaskid FROM atlas_panda.jedi_tasks
WHERE userName = :user AND modificationtime > sysdate-90 AND reqID = :req
```

was doing a full table scan across all partitions (plan cost ~828K, ~33s estimated) because `jedi_tasks` is partitioned by `jeditaskid` and had no index on `reqid` or `username`. Partition pruning is impossible since neither predicate involves the partition key.

A composite index on `(reqid, username)` allows the DB to resolve both equality predicates via an index range lookup, then apply the `modificationtime` filter on the small result set. Since `reqid` is highly selective (a specific workflow submission), this reduces the effective scan from the entire table to a handful of rows.

Note: `reqid` indexes already exist on all the job tables (`JOBSACTIVE4`, `JOBSWAITING4`, `JOBSARCHIVED4`, `JOBSDEFINED4`) — `jedi_tasks` was the only one missing it.

## Changes

- `schema/oracle/ATLAS_PANDA.sql` — add `JEDI_TASKS_REQID_IDX` on `(REQID, USERNAME)`
- `schema/postgres/sqls/pg_PANDA_TABLE.sql` — add `jedi_tasks_reqid_idx` on `(reqid, username)`
- `schema/postgres/sqls/patches/0.1.6.patch.sql` — new patch to apply the index and bump schema to 0.1.6