### PR TITLE
Make post_step_cron.sql idempotent to prevent duplicate cron jobs

### DIFF
--- a/schema/postgres/sqls/patches/0.0.30.cron.patch.sql
+++ b/schema/postgres/sqls/patches/0.0.30.cron.patch.sql
@@ -1,20 +1,14 @@
 -- Cron job updates for patch 0.0.30
--- This file contains cron-specific updates and must be run against the database where pg_cron is installed
---
--- IMPORTANT: pg_cron location varies by installation:
--- Some installations have it in 'postgres' database, others may be in the 'panda_db' database
---
--- To check where pg_cron is installed:
---   SELECT extname FROM pg_extension WHERE extname = 'pg_cron';
---
--- Run this file against the correct database:
---   psql -U postgres -d postgres -f 0.0.30.cron.patch.sql    (if pg_cron is in postgres)
---   psql -U postgres -d panda_db -f 0.0.30.cron.patch.sql    (if pg_cron is in panda_db)
---
--- Regular database updates are in 0.0.30.patch.sql
+-- This file contains cron-specific updates and must be run against the database where pg_cron is installed.
+-- IMPORTANT: pg_cron may be installed in 'postgres' or in 'panda_db'.
+-- To check: SELECT extname FROM pg_extension WHERE extname = 'pg_cron';
 
--- Drop the old cron schedule for the obsolete update_worker_node_map procedure
--- This procedure has been replaced by update_worker_node_metrics
-SELECT cron.unschedule(
-    (SELECT jobid FROM cron.job WHERE command = 'CALL doma_panda.update_worker_node_map()')
-);
+-- NOTE: The original purpose of this file was to unschedule the obsolete
+-- update_worker_node_map procedure. This is now handled automatically by
+-- post_step_cron.sql, which deletes all PanDA-managed cron jobs (including
+-- any obsolete ones) before recreating the current set from scratch.
+-- Run post_step_cron.sql to apply all cron jobs idempotently (ATLASPANDA-1632):
+--
+--   psql -U postgres -d postgres -f ../post_step_cron.sql   -- if pg_cron in 'postgres'
+--   psql -U postgres -d panda_db -f ../post_step_cron.sql   -- if pg_cron in 'panda_db'
+\i ../post_step_cron.sql

--- a/schema/postgres/sqls/patches/0.0.31.cron.patch.sql
+++ b/schema/postgres/sqls/patches/0.0.31.cron.patch.sql
@@ -3,17 +3,13 @@
 -- IMPORTANT: pg_cron may be installed in 'postgres' or in 'panda_db'.
 -- To check: SELECT extname FROM pg_extension WHERE extname = 'pg_cron';
 
--- Examples:
---   psql -U postgres -d postgres -f 0.0.31.cron.patch.sql   -- if pg_cron in 'postgres'
---   psql -U postgres -d panda_db -f 0.0.31.cron.patch.sql   -- if pg_cron in 'panda_db'
-
--- =========================
--- Hourly MV refresh jobs
--- =========================
--- Create top-of-hour schedules for MV refreshes
-SELECT cron.schedule ('0 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY doma_panda.mv_worker_node_summary;');
-SELECT cron.schedule ('0 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY doma_panda.mv_worker_node_gpu_summary;');
-
--- Point the jobs at the correct database/user/node
-UPDATE cron.job SET database = 'panda_db', nodename = '' WHERE command LIKE '%doma_panda.mv_worker_node_summary%';
-UPDATE cron.job SET database = 'panda_db', nodename = '' WHERE command LIKE '%doma_panda.mv_worker_node_gpu_summary%';
+-- NOTE: Instead of adding inline cron.schedule() calls here, the new jobs for this patch
+-- (mv_worker_node_summary and mv_worker_node_gpu_summary hourly refreshes) have been added
+-- to post_step_cron.sql. Run that file to apply all cron jobs from scratch (idempotent):
+--
+--   psql -U postgres -d postgres -f ../post_step_cron.sql   -- if pg_cron in 'postgres'
+--   psql -U postgres -d panda_db -f ../post_step_cron.sql   -- if pg_cron in 'panda_db'
+--
+-- post_step_cron.sql deletes all existing PanDA-managed cron jobs before recreating them,
+-- preventing duplicates if the script is run more than once (ATLASPANDA-1632).
+\i ../post_step_cron.sql

--- a/schema/postgres/sqls/post_step_cron.sql
+++ b/schema/postgres/sqls/post_step_cron.sql
@@ -1,3 +1,12 @@
+-- Remove all existing PanDA-managed cron jobs before recreating them.
+-- This makes the script idempotent: re-running after a failed patch will not
+-- produce duplicate entries in cron.job (ATLASPANDA-1632).
+DELETE FROM cron.job WHERE
+    command LIKE '%doma_panda.%'
+    OR command LIKE '%partman.run_maintenance_proc%'
+    OR command LIKE '%cron.job_run_details%'
+    OR command LIKE '%mv_worker_node%';
+
 SELECT cron.schedule ('* * * * *', 'call doma_panda.jedi_refr_mintaskids_bystatus()');
 SELECT cron.schedule ('* * * * *', 'call doma_panda.update_jobsdef_stats_by_gshare()');
 SELECT cron.schedule ('* * * * *', 'call doma_panda.update_jobsact_stats_by_gshare()');
@@ -6,7 +15,7 @@ SELECT cron.schedule ('* * * * *', 'call doma_panda.update_num_input_data_files(
 SELECT cron.schedule ('* * * * *', 'call doma_panda.update_total_walltime()');
 SELECT cron.schedule ('* * * * *', 'call doma_panda.update_job_stats_hp()');
 UPDATE cron.job SET database='panda_db',username='panda',nodename='' WHERE command like '%doma_panda.%';
-SELECT cron.schedule ('@daily', $$DELETE FROM cron.job_run_details WHERE end_time < now() – interval '3 days'$$);
+SELECT cron.schedule ('@daily', $$DELETE FROM cron.job_run_details WHERE end_time < now() - interval '3 days'$$);
 SELECT cron.schedule ('@daily', 'call partman.run_maintenance_proc()');
 UPDATE cron.job SET database='panda_db',nodename='' WHERE command like '%partman.run_maintenance_proc%';
 SELECT cron.schedule ('0 8 * * *', 'CALL doma_panda.update_worker_node_metrics()');
@@ -16,4 +25,3 @@ SELECT cron.schedule ('0 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY doma_
 UPDATE cron.job SET database = 'panda_db',nodename = '' WHERE command LIKE '%update_worker_node_metrics%';
 UPDATE cron.job SET database = 'panda_db', nodename = '' WHERE command LIKE '%mv_worker_node_summary%';
 UPDATE cron.job SET database = 'panda_db', nodename = '' WHERE command LIKE '%mv_worker_node_gpu_summary%';
-


### PR DESCRIPTION
Fixes ATLASPANDA-1632.

## Problem

`post_step_cron.sql` only calls `cron.schedule()`, which always inserts a new row into `cron.job`. If a patch run fails partway through and the DBA retries, every cron job in the script gets created again, producing duplicates. These duplicates cause real issues — e.g. `update_jobsactive_stats` running 4× per minute inflates `mv_jobsactive4_stats`, making harvester submit far more workers than needed.

## Fix

Prepend a `DELETE` to `post_step_cron.sql` that removes all PanDA-managed cron jobs before recreating them:

```sql
DELETE FROM cron.job WHERE
    command LIKE '%doma_panda.%'
    OR command LIKE '%partman.run_maintenance_proc%'
    OR command LIKE '%cron.job_run_details%'
    OR command LIKE '%mv_worker_node%';
```

The script is now fully idempotent — safe to run multiple times with no side effects.

Also fixes a pre-existing typo: em dash (`–`) used instead of minus (`-`) in the `interval '3 days'` expression, which would cause a SQL error at runtime.

## Convention going forward

`0.0.30.cron.patch.sql` and `0.0.31.cron.patch.sql` have been updated to delegate to `post_step_cron.sql` via `\i` instead of inlining `cron.schedule()` calls. Any future patch that needs to add or modify cron jobs should:

1. Add/update the job in `post_step_cron.sql`
2. In the `.cron.patch.sql` file, use `\i ../post_step_cron.sql` rather than inline `cron.schedule()` calls