### PR TITLE
Add UPDATE GLOBAL INDEXES to all partition drop procedures

### DIFF
--- a/schema/oracle/ATLAS_PANDA.sql
+++ b/schema/oracle/ATLAS_PANDA.sql
@@ -5222,7 +5222,7 @@ FOR j IN 1 .. coll_parts.COUNT LOOP
 	EXECUTE IMMEDIATE stmt INTO messg;
 
 	IF (messg = 'OK') THEN
-		stmt := 'ALTER TABLE DATASETS DROP PARTITION ' || coll_parts(j) ;
+		stmt := 'ALTER TABLE DATASETS DROP PARTITION ' || coll_parts(j) || ' UPDATE GLOBAL INDEXES';
 
 		-- loop until gets exclusive lock on the table
 		LOOP
@@ -5268,8 +5268,7 @@ BEGIN
                       AND t.MODIFICATIONTIME < sysdate - 30' into taskid_cnt;
       
     if (rows_cnt = taskid_cnt and rows_cnt <> 0) then
-      --dbms_output.put_line('ALTER TABLE ATLAS_PANDA.JEDI_Events DROP PARTITION '||p.PARTITION_NAME||' update global indexes;');
-      execute immediate 'ALTER TABLE ATLAS_PANDA.JEDI_Events DROP PARTITION '||p.PARTITION_NAME;
+      execute immediate 'ALTER TABLE ATLAS_PANDA.JEDI_Events DROP PARTITION '||p.PARTITION_NAME||' UPDATE GLOBAL INDEXES';
       --dbms_output.put_line(part_cnt||' '||p.PARTITION_NAME||' >>> '||rows_cnt);
       --row_sum := row_sum + taskid_cnt;
       --part_cnt := part_cnt + 1;
@@ -5510,7 +5509,7 @@ FOR j IN 1 .. coll_parts.COUNT LOOP
 	EXECUTE IMMEDIATE stmt INTO messg;
 
 	IF (messg = 'OK') THEN
-		stmt := 'ALTER TABLE JOBS_STATUSLOG DROP PARTITION ' || coll_parts(j) ;
+		stmt := 'ALTER TABLE JOBS_STATUSLOG DROP PARTITION ' || coll_parts(j) || ' UPDATE GLOBAL INDEXES';
 
 		-- loop until gets exclusive lock on the table
 		LOOP
@@ -5586,7 +5585,7 @@ FOR j IN 1 .. coll_parts.COUNT LOOP
 	EXECUTE IMMEDIATE stmt INTO messg;
 
 	IF (messg = 'OK') THEN
-		stmt := 'ALTER TABLE '|| UPPER(mytab_name)||' DROP PARTITION ' || coll_parts(j) ;
+		stmt := 'ALTER TABLE '|| UPPER(mytab_name)||' DROP PARTITION ' || coll_parts(j) || ' UPDATE GLOBAL INDEXES';
 
 		-- loop until gets exclusive lock on the table
 		LOOP
@@ -5786,7 +5785,7 @@ FOR j IN 1 .. coll_parts.COUNT LOOP
 	EXECUTE IMMEDIATE stmt INTO messg;
 
 	IF (messg = 'OK') THEN
-		stmt := 'ALTER TABLE TASKS_STATUSLOG DROP PARTITION ' || coll_parts(j) ;
+		stmt := 'ALTER TABLE TASKS_STATUSLOG DROP PARTITION ' || coll_parts(j) || ' UPDATE GLOBAL INDEXES';
 
 		-- loop until gets exclusive lock on the table
 		LOOP


### PR DESCRIPTION
## Summary

Five sliding-window and cleanup procedures were dropping partitions without `UPDATE GLOBAL INDEXES`, causing Oracle to mark global non-partitioned indexes as UNUSABLE after each run.

This was the root cause of `TASK_STATUSLOG_JEDITASKID_IDX` becoming UNUSABLE in production on 2026-07-03, resulting in full table scans and task status history queries failing on BigPanDA (reported by Rod Walker, investigated by Tania Korchuganova).

Affected procedures:
- `TASKS_STATUSLOG_SL_WINDOW` — confirmed broken in production, fixed and index rebuilt on 2026-07-07
- `JOBS_STATUSLOG_SL_WINDOW`
- `DATASETS_90DAYS_SL_WINDOW`
- `PANDALOG_SL_WINDOW`
- `DELETE_JEDI_EVENTS_PROC` — `UPDATE GLOBAL INDEXES` was present in a comment but had been commented out

All five procedures now append `UPDATE GLOBAL INDEXES` to the `ALTER TABLE ... DROP PARTITION` statement, which maintains global indexes incrementally during the drop instead of marking them UNUSABLE.

## Test plan

- Verify `TASK_STATUSLOG_JEDITASKID_IDX` remains VALID after the next scheduled run of `TASKS_STATUSLOG_SL_WINDOW` in production
- Confirm BigPanDA task status history loads correctly after the next partition drop